### PR TITLE
Remove high stack memory requirement

### DIFF
--- a/include/sfp/serial_framing_protocol.h
+++ b/include/sfp/serial_framing_protocol.h
@@ -165,6 +165,7 @@ extern "C" {
 /* Return 1 on packet available, 0 on unavailable, -1 on error. */
 int sfpDeliverOctet (SFPcontext *ctx, uint8_t octet, uint8_t *buf, size_t len, size_t *outlen);
 int sfpWritePacket (SFPcontext *ctx, const uint8_t *buf, size_t len, size_t *outlen);
+int sfpWriteFrame (SFPcontext *ctx, SFPpacket *packet, size_t *outlen);
 void sfpConnect (SFPcontext *ctx);
 int sfpIsConnected (SFPcontext *ctx);
 

--- a/src/serial_framing_protocol.cpp
+++ b/src/serial_framing_protocol.cpp
@@ -242,6 +242,22 @@ int sfpWritePacket (SFPcontext *ctx, const uint8_t *buf, size_t len, size_t *out
   return ret;
 }
 
+/* Entry point for transmitter. */
+int sfpWriteFrame (SFPcontext *ctx, SFPpacket *packet, size_t *outlen)
+{
+#ifdef SFP_CONFIG_WARN
+  if (SFP_CONNECT_STATE_CONNECTED != ctx->connectState) {
+    BOOST_LOG(ctx->log) << "(sfp) WARNING: Attempting to send packet on disconnected link.";
+  }
+#endif
+
+  TransmitterLock lock { ctx };
+
+  int ret = sfpTransmitUSR(ctx, packet, outlen);
+
+  return ret;
+}
+
 //////////////////////////////////////////////////////////////////////////////
 
 static int isReservedOctet (uint8_t octet) {


### PR DESCRIPTION
While using libsfp on a Cortex-M4 and FreeRTOS, I've encountered an issue with how the `sfpWritePacket` function works.
Declaring a `Packet` on the stack imposed every tasks on the system that uses this function to have a really high stack in order to call it.

Since in my case `SFP_CONFIG_MAX_PACKET_SIZE` is configured for packets of up to 2200 bytes in length, this meant I would have had to increase the stack of each of theses tasks by more than 2 KB. Obviously unacceptable in a memory constrained micro-controller ;)

I made a simple function replicating the other one, but where the responsibility of creating the `Packet` is left to the user.